### PR TITLE
Implement comprehensive healthcare models

### DIFF
--- a/admin_management/models.py
+++ b/admin_management/models.py
@@ -1,10 +1,13 @@
 from django.db import models
-from django.contrib.auth.models import User
 from django.conf import settings
+import uuid
 
-# Create your models here.
+
 class AuditLog(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True)
-    action = models.CharField(max_length=255)
+    action_type = models.CharField(max_length=255)
+    description = models.TextField()
     timestamp = models.DateTimeField(auto_now_add=True)
-    details = models.TextField(blank=True, null=True)
+    service = models.CharField(max_length=100)
+

--- a/appointment/models.py
+++ b/appointment/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import User
 from django.conf import settings
+import uuid
 
 # Create your models here.
 class Appointment(models.Model):
@@ -11,10 +12,22 @@ class Appointment(models.Model):
         ('cancelled', 'Cancelled'),
     ]
 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     patient = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='appointments_as_patient')
     doctor = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='appointments_as_doctor')
     date_time = models.DateTimeField()
     reason = models.TextField()
     notes = models.TextField(blank=True, null=True)
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='pending')
+
+
+class DoctorNote(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    doctor = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='doctor_notes')
+    patient = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='patient_notes')
+    appointment = models.ForeignKey(Appointment, on_delete=models.CASCADE)
+    symptom_check = models.ForeignKey('symptom_checker.AISymptomCheck', on_delete=models.SET_NULL, null=True, blank=True)
+    note = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
 

--- a/auth_service/models.py
+++ b/auth_service/models.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin, BaseUserManager
 from django.db import models
 from django.conf import settings
+import uuid
 
 class UserManager(BaseUserManager):
     def create_user(self, email, password=None, role='patient', **extra_fields):
@@ -39,6 +40,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         ('rejected', 'Rejected'),
     ]
 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     email = models.EmailField(unique=True)
     role = models.CharField(max_length=20, choices=ROLE_CHOICES)
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='pending')

--- a/chronic_care/models.py
+++ b/chronic_care/models.py
@@ -1,10 +1,19 @@
 from django.db import models
-from django.contrib.auth.models import User
 from django.conf import settings
+import uuid
 
-# Create your models here.
-class ChronicCondition(models.Model):
+
+class ChronicCareLog(models.Model):
+    METRIC_CHOICES = [
+        ('glucose', 'Glucose'),
+        ('bp', 'Blood Pressure'),
+        ('weight', 'Weight'),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     patient = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
-    name = models.CharField(max_length=100)
-    diagnosis_date = models.DateField()
-    treatment_plan = models.TextField()
+    metric_type = models.CharField(max_length=20, choices=METRIC_CHOICES)
+    value = models.FloatField()
+    note = models.TextField(blank=True, null=True)
+    recorded_at = models.DateTimeField()
+

--- a/lab/models.py
+++ b/lab/models.py
@@ -1,11 +1,26 @@
 from django.db import models
-from django.contrib.auth.models import User
 from django.conf import settings
+import uuid
 
-# Create your models here.
-class LabTest(models.Model):
+
+class LabResult(models.Model):
+    TEST_TYPE_CHOICES = [
+        ('blood', 'Blood'),
+        ('urine', 'Urine'),
+        ('MRI', 'MRI'),
+    ]
+
+    STATUS_CHOICES = [
+        ('normal', 'Normal'),
+        ('borderline', 'Borderline'),
+        ('abnormal', 'Abnormal'),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     patient = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
-    test_name = models.CharField(max_length=100)
-    test_date = models.DateField()
-    result = models.TextField()
-    uploaded_by = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='uploaded_tests')
+    uploaded_by = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='lab_results')
+    test_type = models.CharField(max_length=20, choices=TEST_TYPE_CHOICES)
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES)
+    file_url = models.URLField()
+    uploaded_at = models.DateTimeField(auto_now_add=True)
+

--- a/medical_record/models.py
+++ b/medical_record/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import User
 from django.conf import settings
+import uuid
 
 # Create your models here.
 class MedicalRecord(models.Model):
@@ -8,10 +9,14 @@ class MedicalRecord(models.Model):
         ('lab', 'Lab'),
         ('scan', 'Scan'),
         ('note', 'Note'),
+        ('referral', 'Referral'),
+        ('prescription', 'Prescription'),
     ]
 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     patient = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     uploaded_by = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='uploaded_records')
     file_url = models.URLField()
-    type = models.CharField(max_length=10, choices=RECORD_TYPE_CHOICES)
-    uploaded_at = models.DateTimeField(auto_now_add=True)
+    type = models.CharField(max_length=20, choices=RECORD_TYPE_CHOICES)
+    summary = models.TextField()
+    date_uploaded = models.DateTimeField(auto_now_add=True)

--- a/notification/models.py
+++ b/notification/models.py
@@ -1,10 +1,27 @@
 from django.db import models
-from django.contrib.auth.models import User
 from django.conf import settings
+import uuid
 
-# Create your models here.
+
 class Notification(models.Model):
-    recipient = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    TYPE_CHOICES = [
+        ('alert', 'Alert'),
+        ('reminder', 'Reminder'),
+        ('info', 'Info'),
+    ]
+
+    STATUS_CHOICES = [
+        ('sent', 'Sent'),
+        ('read', 'Read'),
+        ('archived', 'Archived'),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    sender = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, related_name='notifications_sent')
+    recipient = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='notifications_received')
+    title = models.CharField(max_length=255)
     message = models.TextField()
-    is_read = models.BooleanField(default=False)
+    type = models.CharField(max_length=20, choices=TYPE_CHOICES)
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='sent')
     sent_at = models.DateTimeField(auto_now_add=True)
+

--- a/pharmacy/models.py
+++ b/pharmacy/models.py
@@ -1,15 +1,19 @@
 from django.db import models
-from django.contrib.auth.models import User
 from django.conf import settings
+import uuid
 
-# Create your models here.
-class PharmacyItem(models.Model):
-    name = models.CharField(max_length=100)
-    stock = models.IntegerField()
-    price = models.DecimalField(max_digits=10, decimal_places=2)
 
-class DispensedMedicine(models.Model):
-    patient = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
-    item = models.ForeignKey(PharmacyItem, on_delete=models.CASCADE)
-    quantity = models.IntegerField()
+class Dispensation(models.Model):
+    STATUS_CHOICES = [
+        ('dispensed', 'Dispensed'),
+        ('partial', 'Partial'),
+        ('unavailable', 'Unavailable'),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    prescription = models.ForeignKey('prescription.PrescriptionHeader', on_delete=models.CASCADE)
+    pharmacist = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES)
+    note = models.TextField(blank=True, null=True)
     dispensed_at = models.DateTimeField(auto_now_add=True)
+

--- a/prescription/models.py
+++ b/prescription/models.py
@@ -1,12 +1,29 @@
 from django.db import models
-from django.contrib.auth.models import User
 from django.conf import settings
+import uuid
 
-# Create your models here.
-class Prescription(models.Model):
-    doctor = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='issued_prescriptions')
-    patient = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='received_prescriptions')
-    medication = models.TextField()
+
+class PrescriptionHeader(models.Model):
+    STATUS_CHOICES = [
+        ('issued', 'Issued'),
+        ('dispensed', 'Dispensed'),
+        ('unavailable', 'Unavailable'),
+        ('partial', 'Partial'),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    patient = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    doctor = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='prescriptions_issued')
+    issued_date = models.DateTimeField(auto_now_add=True)
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='issued')
+
+
+class PrescriptionItem(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    prescription = models.ForeignKey(PrescriptionHeader, on_delete=models.CASCADE, related_name='items')
+    medication_name = models.CharField(max_length=255)
     dosage = models.CharField(max_length=100)
+    frequency = models.CharField(max_length=100)
+    duration = models.CharField(max_length=100)
     instructions = models.TextField()
-    issued_at = models.DateTimeField(auto_now_add=True)
+

--- a/symptom_checker/models.py
+++ b/symptom_checker/models.py
@@ -1,13 +1,62 @@
 from django.db import models
 from django.conf import settings
+import uuid
 
-# Create your models here.
+
 class Symptom(models.Model):
     name = models.CharField(max_length=100)
     description = models.TextField()
+
 
 class Disease(models.Model):
     name = models.CharField(max_length=100)
     description = models.TextField()
     keywords = models.CharField(max_length=255)
     symptoms = models.ManyToManyField(Symptom)
+
+
+class AISymptomCheck(models.Model):
+    RECOMMENDATION_CHOICES = [
+        ('home_care', 'Home Care'),
+        ('consult_doctor', 'Consult Doctor'),
+        ('emergency', 'Emergency'),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    patient = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    input_text = models.TextField()
+    recommendation = models.CharField(max_length=20, choices=RECOMMENDATION_CHOICES)
+    shared_with_doctor = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+
+class AISymptomPrediction(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    symptom_check = models.ForeignKey(AISymptomCheck, on_delete=models.CASCADE, related_name='predictions')
+    condition_name = models.CharField(max_length=255)
+    confidence_score = models.FloatField()
+
+
+class SymptomChecklist(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=100)
+    description = models.TextField()
+    snomed_code = models.CharField(max_length=50)
+    is_active = models.BooleanField(default=True)
+
+
+class EmergencyFlag(models.Model):
+    TRIGGER_CHOICES = [
+        ('AI', 'AI'),
+        ('doctor', 'Doctor'),
+        ('nurse', 'Nurse'),
+    ]
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    patient = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    triggered_by = models.CharField(max_length=10, choices=TRIGGER_CHOICES)
+    reason = models.TextField()
+    related_symptom_check = models.ForeignKey(AISymptomCheck, on_delete=models.SET_NULL, null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    resolved = models.BooleanField(default=False)
+

--- a/vitals/models.py
+++ b/vitals/models.py
@@ -1,13 +1,16 @@
 from django.db import models
-from django.contrib.auth.models import User
 from django.conf import settings
+import uuid
 
 
-# Create your models here.
-class Vitals(models.Model):
+class VitalSigns(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     patient = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
-    recorded_at = models.DateTimeField(auto_now_add=True)
-    heart_rate = models.IntegerField()
-    blood_pressure = models.CharField(max_length=10)  # e.g., 120/80
+    recorded_by = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null=True, related_name='vitals_recorded')
+    recorded_at = models.DateTimeField()
+    blood_pressure = models.CharField(max_length=20)
     temperature = models.FloatField()
-    spo2 = models.IntegerField()  # oxygen saturation
+    heart_rate = models.IntegerField()
+    oxygen_saturation = models.FloatField()
+    respiratory_rate = models.IntegerField()
+


### PR DESCRIPTION
## Summary
- refine `User` with UUID primary key
- flesh out appointments and doctor notes
- expand medical records and lab results
- add detailed prescription, vital signs, chronic care, and pharmacy models
- implement symptom checker and notification models
- add admin audit log tracking

## Testing
- `python manage.py test` *(fails: FileNotFoundError/AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_684a9a1fb17c832e8c5ef41fecb77bbf