### PR TITLE
Fix views/serializers after model changes

### DIFF
--- a/chronic_care/serializers.py
+++ b/chronic_care/serializers.py
@@ -1,9 +1,9 @@
 
 
-from .models import ChronicCondition
+from .models import ChronicCareLog
 from rest_framework import serializers
 
-class ChronicConditionSerializer(serializers.ModelSerializer):
+class ChronicCareLogSerializer(serializers.ModelSerializer):
     class Meta:
-        model = ChronicCondition
+        model = ChronicCareLog
         fields = '__all__'

--- a/chronic_care/urls.py
+++ b/chronic_care/urls.py
@@ -1,7 +1,7 @@
-from .views import ChronicConditionViewSet
+from .views import ChronicCareLogViewSet
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
 router = DefaultRouter()
-router.register(r'chronic-conditions', ChronicConditionViewSet)
+router.register(r'chronic-care-logs', ChronicCareLogViewSet)
 urlpatterns = [path('', include(router.urls))]

--- a/chronic_care/views.py
+++ b/chronic_care/views.py
@@ -1,10 +1,8 @@
-from django.shortcuts import render
-
-# Create your views here.
-from .models import ChronicCondition
-from .serializers import ChronicConditionSerializer
 from rest_framework import viewsets
+from .models import ChronicCareLog
+from .serializers import ChronicCareLogSerializer
 
-class ChronicConditionViewSet(viewsets.ModelViewSet):
-    queryset = ChronicCondition.objects.all()
-    serializer_class = ChronicConditionSerializer
+class ChronicCareLogViewSet(viewsets.ModelViewSet):
+    queryset = ChronicCareLog.objects.all()
+    serializer_class = ChronicCareLogSerializer
+

--- a/lab/serializers.py
+++ b/lab/serializers.py
@@ -1,9 +1,9 @@
 
 
-from .models import LabTest
+from .models import LabResult
 from rest_framework import serializers
 
-class LabTestSerializer(serializers.ModelSerializer):
+class LabResultSerializer(serializers.ModelSerializer):
     class Meta:
-        model = LabTest
+        model = LabResult
         fields = '__all__'

--- a/lab/urls.py
+++ b/lab/urls.py
@@ -1,8 +1,8 @@
-from .views import LabTestViewSet
+from .views import LabResultViewSet
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
 
 router = DefaultRouter()
-router.register(r'lab-tests', LabTestViewSet)
+router.register(r'lab-results', LabResultViewSet)
 urlpatterns = [path('', include(router.urls))]

--- a/lab/views.py
+++ b/lab/views.py
@@ -1,10 +1,11 @@
 from django.shortcuts import render
 
 # Create your views here.
-from .models import LabTest
-from .serializers import LabTestSerializer
+from .models import LabResult
+from .serializers import LabResultSerializer
 from rest_framework import viewsets
 
-class LabTestViewSet(viewsets.ModelViewSet):
-    queryset = LabTest.objects.all()
-    serializer_class = LabTestSerializer
+class LabResultViewSet(viewsets.ModelViewSet):
+    queryset = LabResult.objects.all()
+    serializer_class = LabResultSerializer
+

--- a/pharmacy/serializers.py
+++ b/pharmacy/serializers.py
@@ -1,14 +1,9 @@
 
 
-from .models import PharmacyItem, DispensedMedicine
+from .models import Dispensation
 from rest_framework import serializers
 
-class PharmacyItemSerializer(serializers.ModelSerializer):
+class DispensationSerializer(serializers.ModelSerializer):
     class Meta:
-        model = PharmacyItem
-        fields = '__all__'
-
-class DispensedMedicineSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = DispensedMedicine
+        model = Dispensation
         fields = '__all__'

--- a/pharmacy/urls.py
+++ b/pharmacy/urls.py
@@ -1,8 +1,8 @@
-from .views import PharmacyItemViewSet, DispensedMedicineViewSet
+from .views import DispensationViewSet
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
 router = DefaultRouter()
-router.register(r'pharmacy-items', PharmacyItemViewSet)
-router.register(r'dispensed-medicines', DispensedMedicineViewSet)
+router.register(r'dispensations', DispensationViewSet)
 urlpatterns = [path('', include(router.urls))]
+

--- a/pharmacy/views.py
+++ b/pharmacy/views.py
@@ -1,14 +1,8 @@
-from django.shortcuts import render
 from rest_framework import viewsets
+from .models import Dispensation
+from .serializers import DispensationSerializer
 
-# Create your views here.
-from .models import PharmacyItem, DispensedMedicine
-from .serializers import PharmacyItemSerializer, DispensedMedicineSerializer
+class DispensationViewSet(viewsets.ModelViewSet):
+    queryset = Dispensation.objects.all()
+    serializer_class = DispensationSerializer
 
-class PharmacyItemViewSet(viewsets.ModelViewSet):
-    queryset = PharmacyItem.objects.all()
-    serializer_class = PharmacyItemSerializer
-
-class DispensedMedicineViewSet(viewsets.ModelViewSet):
-    queryset = DispensedMedicine.objects.all()
-    serializer_class = DispensedMedicineSerializer

--- a/prescription/serializers.py
+++ b/prescription/serializers.py
@@ -1,8 +1,15 @@
-
-from .models import Prescription
 from rest_framework import serializers
+from .models import PrescriptionHeader, PrescriptionItem
 
-class PrescriptionSerializer(serializers.ModelSerializer):
+class PrescriptionItemSerializer(serializers.ModelSerializer):
     class Meta:
-        model = Prescription
+        model = PrescriptionItem
         fields = '__all__'
+
+class PrescriptionHeaderSerializer(serializers.ModelSerializer):
+    items = PrescriptionItemSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = PrescriptionHeader
+        fields = ['id', 'patient', 'doctor', 'issued_date', 'status', 'items']
+

--- a/prescription/urls.py
+++ b/prescription/urls.py
@@ -1,7 +1,8 @@
-from .views import PrescriptionViewSet
+from .views import PrescriptionHeaderViewSet, PrescriptionItemViewSet
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
 router = DefaultRouter()
-router.register(r'prescriptions', PrescriptionViewSet)
-urlpatterns = [path('', include(router.urls))] 
+router.register(r'prescription-headers', PrescriptionHeaderViewSet)
+router.register(r'prescription-items', PrescriptionItemViewSet)
+urlpatterns = [path('', include(router.urls))]

--- a/prescription/views.py
+++ b/prescription/views.py
@@ -2,9 +2,14 @@ from django.shortcuts import render
 from rest_framework import viewsets
 
 # Create your views here.
-from .models import Prescription
-from .serializers import PrescriptionSerializer
+from .models import PrescriptionHeader, PrescriptionItem
+from .serializers import PrescriptionHeaderSerializer, PrescriptionItemSerializer
 
-class PrescriptionViewSet(viewsets.ModelViewSet):
-    queryset = Prescription.objects.all()
-    serializer_class = PrescriptionSerializer
+class PrescriptionHeaderViewSet(viewsets.ModelViewSet):
+    queryset = PrescriptionHeader.objects.all()
+    serializer_class = PrescriptionHeaderSerializer
+
+
+class PrescriptionItemViewSet(viewsets.ModelViewSet):
+    queryset = PrescriptionItem.objects.all()
+    serializer_class = PrescriptionItemSerializer

--- a/vitals/serializers.py
+++ b/vitals/serializers.py
@@ -1,8 +1,9 @@
 
 from rest_framework import serializers
-from .models import Vitals
+from .models import VitalSigns
 
-class VitalsSerializer(serializers.ModelSerializer):
+class VitalSignsSerializer(serializers.ModelSerializer):
     class Meta:
-        model = Vitals
+        model = VitalSigns
         fields = '__all__'
+

--- a/vitals/urls.py
+++ b/vitals/urls.py
@@ -1,7 +1,7 @@
-from .views import VitalsViewSet
+from .views import VitalSignsViewSet
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
 router = DefaultRouter()
-router.register(r'vitals', VitalsViewSet)
+router.register(r'vital-signs', VitalSignsViewSet)
 urlpatterns = [path('', include(router.urls))]

--- a/vitals/views.py
+++ b/vitals/views.py
@@ -1,10 +1,11 @@
 from django.shortcuts import render
 
 # Create your views here.
-from .models import Vitals
-from .serializers import VitalsSerializer
+from .models import VitalSigns
+from .serializers import VitalSignsSerializer
 from rest_framework import viewsets
 
-class VitalsViewSet(viewsets.ModelViewSet):
-    queryset = Vitals.objects.all()
-    serializer_class = VitalsSerializer
+class VitalSignsViewSet(viewsets.ModelViewSet):
+    queryset = VitalSigns.objects.all()
+    serializer_class = VitalSignsSerializer
+


### PR DESCRIPTION
## Summary
- update chronic care view/serializer/urls for `ChronicCareLog`
- update lab modules to use `LabResult`
- update pharmacy modules to use `Dispensation`
- update prescription modules to match `PrescriptionHeader`/`PrescriptionItem`
- update vitals modules to use `VitalSigns`

## Testing
- `pip install django==5.1.6`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'corsheaders')*

------
https://chatgpt.com/codex/tasks/task_e_684c8a2ca330832e81a88a64202d103a