### PR TITLE
Add patient profile management

### DIFF
--- a/user_profile/tests.py
+++ b/user_profile/tests.py
@@ -26,3 +26,23 @@ class UserProfileTests(APITestCase):
         self.assertEqual(update_response.status_code, 200)
         self.assertEqual(update_response.data['address'], '456 Avenue')
 
+    def test_my_profile_create_and_update(self):
+        self.client.force_login(self.user)
+        url = reverse('my-profile')
+        data = {
+            'full_name': 'Test Patient',
+            'date_of_birth': '1990-01-01',
+            'gender': 'male',
+            'phone_number': '123456789',
+            'address': '123 Street',
+            'profile_photo': ''
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, 201)
+
+        update_data = data.copy()
+        update_data['address'] = '789 Road'
+        update_response = self.client.put(url, update_data, format='json')
+        self.assertEqual(update_response.status_code, 200)
+        self.assertEqual(update_response.data['address'], '789 Road')
+

--- a/user_profile/urls.py
+++ b/user_profile/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import UserProfileViewSet
+from .views import UserProfileViewSet, MyProfileView
 
 router = DefaultRouter()
 router.register(r'user-profiles', UserProfileViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('me/', MyProfileView.as_view(), name='my-profile'),
 ]

--- a/user_profile/views.py
+++ b/user_profile/views.py
@@ -1,7 +1,54 @@
-from rest_framework import viewsets
+from rest_framework import viewsets, status
+from rest_framework.views import APIView
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
 from .models import UserProfile
 from .serializers import UserProfileSerializer
+
 
 class UserProfileViewSet(viewsets.ModelViewSet):
     queryset = UserProfile.objects.all()
     serializer_class = UserProfileSerializer
+
+
+class MyProfileView(APIView):
+    """Allow a logged in user to create or update their own profile."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get_profile(self, user):
+        try:
+            return UserProfile.objects.get(user=user)
+        except UserProfile.DoesNotExist:
+            return None
+
+    def get(self, request):
+        profile = self.get_profile(request.user)
+        if not profile:
+            return Response({"detail": "Profile not found"}, status=status.HTTP_404_NOT_FOUND)
+        serializer = UserProfileSerializer(profile)
+        return Response(serializer.data)
+
+    def post(self, request):
+        if self.get_profile(request.user):
+            return Response({"detail": "Profile already exists"}, status=status.HTTP_400_BAD_REQUEST)
+        data = request.data.copy()
+        data["user"] = str(request.user.id)
+        serializer = UserProfileSerializer(data=data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def put(self, request):
+        profile = self.get_profile(request.user)
+        if not profile:
+            return Response({"detail": "Profile not found"}, status=status.HTTP_404_NOT_FOUND)
+        data = request.data.copy()
+        data["user"] = str(request.user.id)
+        serializer = UserProfileSerializer(profile, data=data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary
- allow logged in users to create and update their own profile
- route `/api/user-profile/me/` for patient self profile management
- unit tests for the new endpoint

## Testing
- `python manage.py test user_profile` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684db0856248832e89507ef3689f793d