### PR TITLE
Fix appointment creation for doctors

### DIFF
--- a/appointment/views.py
+++ b/appointment/views.py
@@ -109,6 +109,10 @@ def create_appointment_from_chatbot(request):
     date_time_str = data.get('date_time')
     reason = data.get('reason', 'Đặt lịch qua chatbot')
 
+    # Chỉ cho phép bệnh nhân đặt lịch qua chatbot
+    if request.user.role != 'patient':
+        return Response({"error": "Chỉ bệnh nhân mới được phép đặt lịch."}, status=403)
+
     try:
         doctor_profile = UserProfile.objects.get(full_name__icontains=doctor_name, user__role='doctor')
         doctor = doctor_profile.user
@@ -118,6 +122,10 @@ def create_appointment_from_chatbot(request):
     date_time = parse_datetime(date_time_str)
     if not date_time:
         return Response({"error": "Thời gian không hợp lệ"}, status=400)
+
+    # Không cho phép bác sĩ và bệnh nhân trùng nhau
+    if request.user == doctor:
+        return Response({"error": "Bác sĩ và bệnh nhân không được trùng nhau."}, status=400)
 
     # Tạo lịch hẹn
     appointment = Appointment.objects.create(

--- a/chatbot/views.py
+++ b/chatbot/views.py
@@ -75,6 +75,15 @@ def appointment_chatbot_view(request):
     message = None
     response = ""
 
+    # Chỉ bệnh nhân mới được đặt lịch qua chatbot
+    if request.user.role != "patient":
+        return render(request, "appointment/chat_appointment.html", {
+            "form": ChatForm(),
+            "bot_message": "Chỉ bệnh nhân mới được phép đặt lịch.",
+            "step": 0,
+            "doctors": UserProfile.objects.filter(user__role="doctor")
+        })
+
     if request.method == "POST":
         form = ChatForm(request.POST)
         message = form.data.get("message", "").strip()


### PR DESCRIPTION
## Summary
- prevent doctors from booking with themselves in `create_appointment_from_chatbot`
- restrict chatbot appointment flow to patient users only

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684de2ae4310832e92e16b015f3c0dbc