### PR TITLE
Fix chatbot self booking bug

### DIFF
--- a/appointment/tests.py
+++ b/appointment/tests.py
@@ -2,6 +2,7 @@ from django.urls import reverse
 from rest_framework.test import APITestCase
 from auth_service.models import User
 from user_profile.models import UserProfile
+from appointment.models import Appointment
 
 
 class AppointmentChatbotTests(APITestCase):
@@ -30,6 +31,15 @@ class AppointmentChatbotTests(APITestCase):
         })
         self.assertEqual(response.status_code, 200)
         self.assertIn('Do you confirm', response.context['bot_message'])
+
+        # Confirm the appointment
+        response = self.client.post(url, {'message': 'yes'})
+        self.assertEqual(response.status_code, 200)
+
+        appt = Appointment.objects.first()
+        self.assertIsNotNone(appt)
+        self.assertNotEqual(appt.patient_id, appt.doctor_id)
+        self.assertEqual(appt.doctor_id, self.doctor.id)
 
 
 

--- a/chatbot/views.py
+++ b/chatbot/views.py
@@ -94,19 +94,23 @@ def appointment_chatbot_view(request):
         if state.get("step") == "confirm":
             if message.lower() in ["yes", "y"]:
                 doctor = UserProfile.objects.get(user_id=state["doctor_id"])
-                dt = dateparser.parse(state["date_time"]) if dateparser else None
-                if dt and timezone.is_naive(dt):
-                    dt = timezone.make_aware(dt, timezone.get_current_timezone())
+                if doctor.user == request.user:
+                    response = "❌ You cannot book an appointment with yourself."
+                    state = {"step": 0}
+                else:
+                    dt = dateparser.parse(state["date_time"]) if dateparser else None
+                    if dt and timezone.is_naive(dt):
+                        dt = timezone.make_aware(dt, timezone.get_current_timezone())
 
-                Appointment.objects.create(
-                    patient=request.user,
-                    doctor=doctor.user,
-                    date_time=dt,
-                    reason="Confirmed via chatbot",
-                    status="pending"
-                )
-                response = f"✅ Your appointment with Dr. {doctor.full_name} at {dt.strftime('%H:%M on %d/%m/%Y')} has been confirmed."
-                state = {"step": 0}
+                    Appointment.objects.create(
+                        patient=request.user,
+                        doctor=doctor.user,
+                        date_time=dt,
+                        reason="Confirmed via chatbot",
+                        status="pending"
+                    )
+                    response = f"✅ Your appointment with Dr. {doctor.full_name} at {dt.strftime('%H:%M on %d/%m/%Y')} has been confirmed."
+                    state = {"step": 0}
             else:
                 response = "❌ Appointment canceled. Please enter a new request or select again."
                 state = {"step": 0}


### PR DESCRIPTION
## Summary
- test to ensure appointment stores correct doctor
- prevent self booking when confirming appointment in chatbot

## Testing
- `pytest appointment/tests.py --ds=smartphc.settings -q`

------
https://chatgpt.com/codex/tasks/task_e_684de60acf80832ea8b159344599361f