### PR TITLE
Add appointment cancellation flows

### DIFF
--- a/appointment/templates/doctor_schedule.html
+++ b/appointment/templates/doctor_schedule.html
@@ -15,7 +15,6 @@
     <p>SĐT: {{ a.patient_profile.phone_number }}</p>
     <p>Giới tính: {{ a.patient_profile.gender }}</p>
     <p>Ngày sinh: {{ a.patient_profile.date_of_birth }}</p>
-
     <form method="post" action="{% url 'update-appointment' a.id %}">
       {% csrf_token %}
       <label for="status">Cập nhật trạng thái:</label>
@@ -30,6 +29,16 @@
       <br>
       <button type="submit" class="btn btn-primary">💾 Lưu thay đổi</button>
     </form>
+    {% if a.status == 'pending' %}
+    <form method="post" action="{% url 'respond-appointment' a.id 'accept' %}" class="d-inline">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-success btn-sm mt-2">Chấp nhận</button>
+    </form>
+    <form method="post" action="{% url 'respond-appointment' a.id 'reject' %}" class="d-inline">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-danger btn-sm mt-2">Từ chối</button>
+    </form>
+    {% endif %}
   </div>
 {% empty %}
   <div class="alert alert-info">Không có lịch khám nào.</div>

--- a/appointment/templates/patient_schedule.html
+++ b/appointment/templates/patient_schedule.html
@@ -9,6 +9,10 @@
     <p><strong>Trạng thái:</strong> {{ a.get_status_display }}</p>
     <p><strong>Lý do khám:</strong> {{ a.reason }}</p>
     <p><strong>Ghi chú:</strong> {{ a.notes|default:"(Không có)" }}</p>
+    <form method="post" action="{% url 'cancel-appointment' a.id %}">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-danger btn-sm mt-2">Huỷ lịch</button>
+    </form>
   </div>
 {% empty %}
   <div class="alert alert-info">Không có lịch khám nào.</div>

--- a/appointment/tests.py
+++ b/appointment/tests.py
@@ -3,6 +3,7 @@ from rest_framework.test import APITestCase
 from auth_service.models import User
 from user_profile.models import UserProfile
 from appointment.models import Appointment
+from django.utils import timezone
 
 
 class AppointmentChatbotTests(APITestCase):
@@ -40,6 +41,55 @@ class AppointmentChatbotTests(APITestCase):
         self.assertIsNotNone(appt)
         self.assertNotEqual(appt.patient_id, appt.doctor_id)
         self.assertEqual(appt.doctor_id, self.doctor.id)
+
+
+class AppointmentActionTests(APITestCase):
+    def setUp(self):
+        self.patient = User.objects.create_user(
+            email='testpat@example.com', password='pass1234', role='patient', status='approved'
+        )
+        self.doctor = User.objects.create_user(
+            email='testdoc@example.com', password='pass1234', role='doctor', status='approved'
+        )
+        UserProfile.objects.create(
+            user=self.doctor,
+            full_name='Dr. Action',
+            date_of_birth='1980-01-01',
+            gender='male',
+            phone_number='123',
+            address='abc'
+        )
+        self.appointment = Appointment.objects.create(
+            patient=self.patient,
+            doctor=self.doctor,
+            date_time=timezone.now() + timezone.timedelta(days=1),
+            reason='test',
+            status='pending'
+        )
+
+    def test_patient_cancel(self):
+        self.client.force_login(self.patient)
+        url = reverse('cancel-appointment', args=[self.appointment.id])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+        self.appointment.refresh_from_db()
+        self.assertEqual(self.appointment.status, 'cancelled')
+
+    def test_doctor_accept(self):
+        self.client.force_login(self.doctor)
+        url = reverse('respond-appointment', args=[self.appointment.id, 'accept'])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+        self.appointment.refresh_from_db()
+        self.assertEqual(self.appointment.status, 'confirmed')
+
+    def test_doctor_reject(self):
+        self.client.force_login(self.doctor)
+        url = reverse('respond-appointment', args=[self.appointment.id, 'reject'])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
+        self.appointment.refresh_from_db()
+        self.assertEqual(self.appointment.status, 'cancelled')
 
 
 

--- a/appointment/urls.py
+++ b/appointment/urls.py
@@ -2,10 +2,18 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from .views import doctor_schedule_view, update_appointment_view, patient_schedule_view
+from .views import (
+    doctor_schedule_view,
+    update_appointment_view,
+    patient_schedule_view,
+    cancel_appointment,
+    respond_appointment,
+)
 
 urlpatterns = [
     path('schedule/', doctor_schedule_view, name='doctor-schedule'),
     path('schedule/update/<uuid:appointment_id>/', update_appointment_view, name='update-appointment'),
     path('my/', patient_schedule_view, name='patient-schedule'),
+    path('cancel/<uuid:appointment_id>/', cancel_appointment, name='cancel-appointment'),
+    path('schedule/respond/<uuid:appointment_id>/<str:action>/', respond_appointment, name='respond-appointment'),
 ]

--- a/appointment/views.py
+++ b/appointment/views.py
@@ -183,3 +183,29 @@ def patient_schedule_view(request):
         'upcoming': upcoming,
         'history': history,
     })
+
+
+@login_required
+def cancel_appointment(request, appointment_id):
+    """Allow a patient to cancel their appointment."""
+    appointment = get_object_or_404(Appointment, id=appointment_id, patient=request.user)
+    if request.method == 'POST':
+        appointment.status = 'cancelled'
+        appointment.save()
+        messages.success(request, "Đã hủy lịch hẹn.")
+    return redirect('patient-schedule')
+
+
+@login_required
+def respond_appointment(request, appointment_id, action):
+    """Doctor accepts or rejects an appointment."""
+    appointment = get_object_or_404(Appointment, id=appointment_id, doctor=request.user)
+    if request.method == 'POST':
+        if action == 'accept':
+            appointment.status = 'confirmed'
+            messages.success(request, "Đã chấp nhận lịch hẹn.")
+        elif action == 'reject':
+            appointment.status = 'cancelled'
+            messages.success(request, "Đã từ chối lịch hẹn.")
+        appointment.save()
+    return redirect('doctor-schedule')


### PR DESCRIPTION
## Summary
- allow patients to cancel appointments
- let doctors accept or reject appointments
- update appointment URLs and templates
- test new patient and doctor flows

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684de87891e4832e9f6a5911afeab6e1