### PR TITLE
Add medical record links to patient views

### DIFF
--- a/appointment/templates/base.html
+++ b/appointment/templates/base.html
@@ -37,6 +37,9 @@
           <li class="nav-item">
             <a class="nav-link" href="{% url 'patient-schedule' %}">My Appointments</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{% url 'my-medical-history' %}">Medical Records</a>
+          </li>
           {% endif %}
         </ul>
         <ul class="navbar-nav ms-auto">

--- a/auth_service/templates/home.html
+++ b/auth_service/templates/home.html
@@ -18,6 +18,9 @@
         <li class="nav-item">
           <a class="nav-link" href="/doctor/my/">My Appointments</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{% url 'my-medical-history' %}">Medical Records</a>
+        </li>
       </ul>
       <ul class="navbar-nav ms-auto">
         <li class="nav-item">


### PR DESCRIPTION
## Summary
- show medical records menu option in the navigation bar used across patient pages
- expose medical record link on the patient home page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684df10bb9c0832e9233d0535479ca58