### PR TITLE
Add patient medical record creation and doctor search links

### DIFF
--- a/appointment/templates/base.html
+++ b/appointment/templates/base.html
@@ -27,6 +27,9 @@
           <li class="nav-item">
             <a class="nav-link" href="{% url 'doctor-schedule' %}">📅 Lịch khám</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{% url 'search-medical-history' %}">Tra cứu hồ sơ</a>
+          </li>
           {% else %}
           <li class="nav-item">
             <a class="nav-link" href="/api/chatbot/chat/">Symptom Checker</a>

--- a/appointment/templates/doctor_schedule.html
+++ b/appointment/templates/doctor_schedule.html
@@ -1,6 +1,12 @@
 {% extends "base.html" %}
 {% block content %}
 <h2 class="mb-4">📅 Lịch khám của bạn</h2>
+<form method="get" action="{% url 'search-medical-history' %}" class="mb-4">
+  <div class="input-group">
+    <input type="text" name="q" class="form-control" placeholder="Nhập tên bệnh nhân">
+    <button type="submit" class="btn btn-primary">Tìm hồ sơ</button>
+  </div>
+</form>
 
 <h4>Sắp tới</h4>
 {% for a in upcoming %}

--- a/medical_record/templates/medical_record/add_record.html
+++ b/medical_record/templates/medical_record/add_record.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="mb-4">Thêm hồ sơ bệnh án</h2>
+<form method="post">
+  {% csrf_token %}
+  <div class="mb-3">
+    <label class="form-label">Loại</label>
+    <select name="type" class="form-select">
+      {% for key,val in record_types %}
+        <option value="{{ key }}">{{ val }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">File URL</label>
+    <input type="text" name="file_url" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Tóm tắt</label>
+    <textarea name="summary" class="form-control"></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary">➕ Thêm</button>
+</form>
+{% endblock %}

--- a/medical_record/templates/medical_record/my_history.html
+++ b/medical_record/templates/medical_record/my_history.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h2 class="mb-4">🩺 Hồ sơ bệnh án của tôi</h2>
+<a href="{% url 'add-medical-record' %}" class="btn btn-success mb-3">➕ Thêm hồ sơ</a>
 {% for r in records %}
   <div class="card mb-3 p-3 shadow-sm">
     <h5>{{ r.get_type_display }} - {{ r.date_uploaded|date:"H:i d/m/Y" }}</h5>

--- a/medical_record/urls.py
+++ b/medical_record/urls.py
@@ -1,6 +1,7 @@
 from .views import (
     MedicalRecordViewSet,
     my_medical_history_view,
+    add_medical_record_view,
     search_medical_history_view,
     update_medical_record_view,
 )
@@ -12,6 +13,7 @@ router.register(r'medical-records', MedicalRecordViewSet)
 urlpatterns = [
     path('', include(router.urls)),
     path('my-history/', my_medical_history_view, name='my-medical-history'),
+    path('add/', add_medical_record_view, name='add-medical-record'),
     path('search-history/', search_medical_history_view, name='search-medical-history'),
     path('update/<uuid:record_id>/', update_medical_record_view, name='update-medical-record'),
 ]


### PR DESCRIPTION
## Summary
- allow patients to create medical records
- add medical record link in patient history page
- provide search links and forms for doctors

## Testing
- `python manage.py test` *(fails: IntegrityError in appointment tests)*

------
https://chatgpt.com/codex/tasks/task_e_684df25893e0832e9523f0e97679e7bc