### PR TITLE
Add vitals management for patients

### DIFF
--- a/appointment/templates/base.html
+++ b/appointment/templates/base.html
@@ -43,6 +43,9 @@
           <li class="nav-item">
             <a class="nav-link" href="{% url 'my-medical-history' %}">Medical Records</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="{% url 'my-vitals' %}">Vitals</a>
+          </li>
           {% endif %}
         </ul>
         <ul class="navbar-nav ms-auto">

--- a/vitals/templates/vitals/add_vital.html
+++ b/vitals/templates/vitals/add_vital.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="mb-4">Thêm chỉ số sức khỏe</h2>
+<form method="post">
+  {% csrf_token %}
+  <div class="mb-3">
+    <label class="form-label">Huyết áp</label>
+    <input type="text" name="blood_pressure" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Nhiệt độ (&deg;C)</label>
+    <input type="number" step="0.1" name="temperature" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Nhịp tim (bpm)</label>
+    <input type="number" name="heart_rate" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">SpO2 (%)</label>
+    <input type="number" step="0.1" name="oxygen_saturation" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Nhịp thở (lần/phút)</label>
+    <input type="number" name="respiratory_rate" class="form-control">
+  </div>
+  <button type="submit" class="btn btn-primary">➕ Thêm</button>
+</form>
+{% endblock %}

--- a/vitals/templates/vitals/my_vitals.html
+++ b/vitals/templates/vitals/my_vitals.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="mb-4">📊 Chỉ số sức khỏe của tôi</h2>
+<a href="{% url 'add-vital-sign' %}" class="btn btn-success mb-3">➕ Thêm chỉ số</a>
+{% for v in vitals %}
+  <div class="card mb-3 p-3 shadow-sm position-relative">
+    <h5>{{ v.recorded_at|date:"H:i - d/m/Y" }}</h5>
+    <p><strong>Huyết áp:</strong> {{ v.blood_pressure }}</p>
+    <p><strong>Nhiệt độ:</strong> {{ v.temperature }}°C</p>
+    <p><strong>Nhịp tim:</strong> {{ v.heart_rate }} bpm</p>
+    <a href="{% url 'vital-detail' v.id %}" class="stretched-link"></a>
+  </div>
+{% empty %}
+  <div class="alert alert-info">Không có dữ liệu chỉ số.</div>
+{% endfor %}
+{% endblock %}

--- a/vitals/templates/vitals/vital_detail.html
+++ b/vitals/templates/vitals/vital_detail.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="mb-4">Chi tiết chỉ số</h2>
+<div class="card p-3 shadow-sm">
+  <h5>{{ vital.recorded_at|date:"H:i - d/m/Y" }}</h5>
+  <p><strong>Huyết áp:</strong> {{ vital.blood_pressure }}</p>
+  <p><strong>Nhiệt độ:</strong> {{ vital.temperature }}°C</p>
+  <p><strong>Nhịp tim:</strong> {{ vital.heart_rate }} bpm</p>
+  <p><strong>SpO2:</strong> {{ vital.oxygen_saturation }}%</p>
+  <p><strong>Nhịp thở:</strong> {{ vital.respiratory_rate }} lần/phút</p>
+</div>
+{% endblock %}

--- a/vitals/urls.py
+++ b/vitals/urls.py
@@ -1,7 +1,17 @@
-from .views import VitalSignsViewSet
+from .views import (
+    VitalSignsViewSet,
+    my_vitals_view,
+    add_vital_sign_view,
+    vital_detail_view,
+)
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
 router = DefaultRouter()
 router.register(r'vital-signs', VitalSignsViewSet)
-urlpatterns = [path('', include(router.urls))]
+urlpatterns = [
+    path('', include(router.urls)),
+    path('my/', my_vitals_view, name='my-vitals'),
+    path('add/', add_vital_sign_view, name='add-vital-sign'),
+    path('detail/<uuid:vital_id>/', vital_detail_view, name='vital-detail'),
+]

--- a/vitals/views.py
+++ b/vitals/views.py
@@ -1,4 +1,7 @@
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404, redirect
+from django.utils import timezone
+from django.contrib.auth.decorators import login_required
+from django.contrib import messages
 
 # Create your views here.
 from .models import VitalSigns
@@ -8,4 +11,62 @@ from rest_framework import viewsets
 class VitalSignsViewSet(viewsets.ModelViewSet):
     queryset = VitalSigns.objects.all()
     serializer_class = VitalSignsSerializer
+
+
+@login_required
+def my_vitals_view(request):
+    """Display vital sign history for the logged in patient."""
+    if request.user.role != "patient":
+        messages.error(request, "Bạn không có quyền truy cập.")
+        return redirect("home")
+
+    vitals = (
+        VitalSigns.objects.filter(patient=request.user)
+        .order_by("-recorded_at")
+    )
+    return render(request, "vitals/my_vitals.html", {"vitals": vitals})
+
+
+@login_required
+def add_vital_sign_view(request):
+    """Allow a patient to add new vital sign data."""
+    if request.user.role != "patient":
+        messages.error(request, "Bạn không có quyền truy cập.")
+        return redirect("home")
+
+    if request.method == "POST":
+        bp = request.POST.get("blood_pressure", "").strip()
+        temp = request.POST.get("temperature")
+        hr = request.POST.get("heart_rate")
+        spo2 = request.POST.get("oxygen_saturation")
+        rr = request.POST.get("respiratory_rate")
+
+        if not all([bp, temp, hr, spo2, rr]):
+            messages.error(request, "Vui lòng điền đầy đủ thông tin.")
+        else:
+            VitalSigns.objects.create(
+                patient=request.user,
+                recorded_by=request.user,
+                recorded_at=timezone.now(),
+                blood_pressure=bp,
+                temperature=temp,
+                heart_rate=hr,
+                oxygen_saturation=spo2,
+                respiratory_rate=rr,
+            )
+            messages.success(request, "Đã thêm chỉ số.")
+            return redirect("my-vitals")
+
+    return render(request, "vitals/add_vital.html")
+
+
+@login_required
+def vital_detail_view(request, vital_id):
+    """Show details for a single vital sign entry."""
+    vital = get_object_or_404(VitalSigns, id=vital_id, patient=request.user)
+    if request.user.role != "patient":
+        messages.error(request, "Bạn không có quyền truy cập.")
+        return redirect("home")
+
+    return render(request, "vitals/vital_detail.html", {"vital": vital})
 


### PR DESCRIPTION
## Summary
- allow patients to add and review their vital signs
- show a link to "Vitals" on the patient navbar
- list vital history and view detailed entries

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684e386a19dc832eb9cff8f5a2a31b5a