### PR TITLE
Fix patient home navigation

### DIFF
--- a/auth_service/templates/home.html
+++ b/auth_service/templates/home.html
@@ -16,10 +16,13 @@
           <a class="nav-link" href="/api/chatbot/appointment/">Book Appointment</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/doctor/my/">My Appointments</a>
+          <a class="nav-link" href="{% url 'patient-schedule' %}">My Appointments</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="{% url 'my-medical-history' %}">Medical Records</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{% url 'my-vitals' %}">Vitals</a>
         </li>
       </ul>
       <ul class="navbar-nav ms-auto">


### PR DESCRIPTION
## Summary
- show Vitals menu item on the patient homepage
- fix "My Appointments" link to use the correct URL

## Testing
- `pytest -q`
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684e3d918a30832e81801c2bd75952f7