### PR TITLE
Add nurse patient management views

### DIFF
--- a/appointment/templates/base.html
+++ b/appointment/templates/base.html
@@ -30,6 +30,10 @@
           <li class="nav-item">
             <a class="nav-link" href="{% url 'search-medical-history' %}">Tra cứu hồ sơ</a>
           </li>
+          {% elif request.user.role == "nurse" %}
+          <li class="nav-item">
+            <a class="nav-link" href="{% url 'nurse-patient-list' %}">Patients</a>
+          </li>
           {% else %}
           <li class="nav-item">
             <a class="nav-link" href="/api/chatbot/chat/">Symptom Checker</a>

--- a/auth_service/templates/nurse_patient_detail.html
+++ b/auth_service/templates/nurse_patient_detail.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="mb-3">{{ profile.full_name }} ({{ patient.email }})</h2>
+<a href="{% url 'nurse-add-vital' patient.id %}" class="btn btn-success mb-4">➕ Thêm chỉ số</a>
+<h4>Chỉ số sức khỏe</h4>
+{% for v in vitals %}
+<div class="card mb-2 p-2">
+  <strong>{{ v.recorded_at|date:"H:i d/m/Y" }}</strong>
+  <p>Huyết áp: {{ v.blood_pressure }} | Nhiệt độ: {{ v.temperature }}°C | Nhịp tim: {{ v.heart_rate }} bpm</p>
+</div>
+{% empty %}
+<p>Không có chỉ số.</p>
+{% endfor %}
+<h4 class="mt-4">Hồ sơ bệnh án</h4>
+{% for r in records %}
+<div class="card mb-2 p-2">
+  <strong>{{ r.get_type_display }} - {{ r.date_uploaded|date:"H:i d/m/Y" }}</strong>
+  <p>{{ r.summary }}</p>
+  <a href="{{ r.file_url }}" target="_blank">📄 Xem file</a>
+</div>
+{% empty %}
+<p>Không có hồ sơ.</p>
+{% endfor %}
+{% endblock %}

--- a/auth_service/templates/nurse_patient_list.html
+++ b/auth_service/templates/nurse_patient_list.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="mb-4">Danh sách bệnh nhân</h2>
+<ul class="list-group">
+  {% for p in patients %}
+  <li class="list-group-item">
+    <a href="{% url 'nurse-patient-detail' p.user.id %}">{{ p.full_name }} - {{ p.user.email }}</a>
+  </li>
+  {% empty %}
+  <li class="list-group-item">Không có bệnh nhân.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/auth_service/urls.py
+++ b/auth_service/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 from . import views
+from vitals import views as vitals_views
 
 urlpatterns = [
     path('login/', views.login_view, name='login'),
@@ -8,5 +9,8 @@ urlpatterns = [
     path('home/', views.home_view, name='home'),  # Thêm route home tại đây
     path('profile/', views.profile_view, name='profile'),
     path('nurse/', views.nurse_home_view, name='nurse-home'),
+    path('nurse/patients/', views.nurse_patient_list_view, name='nurse-patient-list'),
+    path('nurse/patients/<uuid:patient_id>/', views.nurse_patient_detail_view, name='nurse-patient-detail'),
+    path('nurse/patients/<uuid:patient_id>/add-vital/', vitals_views.add_vital_for_patient_view, name='nurse-add-vital'),
     path('lab/', views.lab_home_view, name='lab-home'),
 ]

--- a/vitals/templates/vitals/nurse_add_vital.html
+++ b/vitals/templates/vitals/nurse_add_vital.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block content %}
+<h2 class="mb-4">Thêm chỉ số cho {{ profile.full_name }}</h2>
+<form method="post">
+  {% csrf_token %}
+  <div class="mb-3">
+    <label class="form-label">Huyết áp</label>
+    <input type="text" name="blood_pressure" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Nhiệt độ (&deg;C)</label>
+    <input type="number" step="0.1" name="temperature" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Nhịp tim (bpm)</label>
+    <input type="number" name="heart_rate" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">SpO2 (%)</label>
+    <input type="number" step="0.1" name="oxygen_saturation" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Nhịp thở (lần/phút)</label>
+    <input type="number" name="respiratory_rate" class="form-control">
+  </div>
+  <button type="submit" class="btn btn-primary">➕ Thêm</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- show nurse patient list in navigation
- add nurse patient list and detail views
- allow nurses to record vitals for a patient
- wire up URLs and templates

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684e40a9c8f4832e9bff06fe53cbfa42