### PR TITLE
Add Docker support and docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir Django djangorestframework django-cors-headers neo4j
+EXPOSE 8000
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # smartphc
-# healthycare
+
+HealthyCare là hệ thống quản lý y tế xây dựng trên nền tảng Django.
+
+## Các service
+- auth_service
+- user_profile
+- appointment
+- medical_record
+- symptom_checker
+- chatbot
+- prescription
+- vitals
+- chronic_care
+- lab
+- pharmacy
+- notification
+- admin_management
+
+## Kết nối dịch vụ với Docker
+Dự án có thể chạy bằng Docker để đơn giản hóa việc cài đặt. Sử dụng file `docker-compose.yml` để khởi tạo các service.
+
+### Cách sử dụng
+1. Cài đặt Docker và Docker Compose.
+2. Chạy các service:
+   ```bash
+   docker-compose up --build
+   ```
+3. Truy cập ứng dụng tại `http://localhost:8000/`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose for easy startup
- document available Django services
- explain how to run the project using Docker

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684e7996a5d0832eae606a45c2cb886a